### PR TITLE
story7 : refelction

### DIFF
--- a/src/main/java/org/example/story7/BuchuClass.java
+++ b/src/main/java/org/example/story7/BuchuClass.java
@@ -1,0 +1,29 @@
+package org.example.story7;
+
+/**
+ * Reflection 사용하기 위한 demo class
+ */
+public class BuchuClass {
+    // 접근 제어자가 다른 fields
+    private String privateField;
+    String defaultField;
+    protected String protectedField;
+    public String publicField;
+
+    // constructor
+    public BuchuClass() {}
+    public BuchuClass(String arg) {}
+
+    // methods
+    public void publicMethod() {}
+    public String publicMethod(String s, int i) {
+        return "s: " + s + ", i: " + i;
+    }
+    protected void protectedMethod() {}
+    void method() {}
+    private void privateMethod() {}
+    public InnerClass getInnerClass() {
+        return new InnerClass();
+    }
+    public static class InnerClass {}
+}

--- a/src/main/java/org/example/story7/BuchuReflection.java
+++ b/src/main/java/org/example/story7/BuchuReflection.java
@@ -1,0 +1,65 @@
+package org.example.story7;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.Parameter;
+
+public class BuchuReflection {
+    public static Class getClassByReflection(Object clazz) {
+        return clazz.getClass();
+    }
+
+    public static void showClassInfo(Class demoClass) {
+        String className = demoClass.getName();
+        System.out.println("class name: " + className);
+
+        String canonicalClassName = demoClass.getCanonicalName();
+        System.out.println("canonical class name: " + canonicalClassName);
+
+        String simpleClassName = demoClass.getSimpleName();
+        System.out.println("simple class name: " + simpleClassName);
+
+        String packageName = demoClass.getPackageName();
+        System.out.println("package name: " + packageName);
+
+        String toString = demoClass.toString();
+        System.out.println("toString: " + toString);
+    }
+
+    public static void showFieldInfo(Class demoClass) {
+        Field[] fields = demoClass.getFields();
+        Field[] declaredFields = demoClass.getDeclaredFields();
+
+        System.out.format("length of fields & declaredFields: %d, %d\n",
+                fields.length,
+                declaredFields.length);
+
+        for (Field field : declaredFields) {
+            String fieldName = field.getName();
+            String modifier = Modifier.toString(field.getModifiers());
+            String fieldType = field.getType().getSimpleName();
+
+            System.out.format("%s %s %s\n", modifier, fieldType, fieldName);
+        }
+    }
+
+    public static void showMethodInfo(Class demoClass) {
+        Method[] methods = demoClass.getMethods();
+        for (Method method : methods) {
+            String name = method.getName();
+            String modifier = Modifier.toString(method.getModifiers());
+            Parameter[] parameters = method.getParameters();
+
+            System.out.format("method: %s %s\n", modifier, name);
+
+            System.out.format("parameter: ");
+            for (Parameter parameter : parameters) {
+                System.out.format("%s %s; ",
+                        parameter.getType().getSimpleName(),
+                        parameter.getName());
+            }
+            System.out.println();
+        }
+    }
+}

--- a/src/test/java/org/example/story7/BuchuClassTest.java
+++ b/src/test/java/org/example/story7/BuchuClassTest.java
@@ -1,0 +1,33 @@
+package org.example.story7;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class BuchuClassTest {
+    @Test
+    @DisplayName("reflection class 테스트")
+    public void reflectionClassTest() {
+        BuchuClass buchuClass = new BuchuClass();
+        Class clazz = BuchuReflection.getClassByReflection(buchuClass);
+
+        BuchuReflection.showClassInfo(clazz);
+    }
+
+    @Test
+    @DisplayName("reflection field 테스트")
+    public void reflectionFieldTest() {
+        BuchuClass buchuClass = new BuchuClass();
+        Class clazz = BuchuReflection.getClassByReflection(buchuClass);
+
+        BuchuReflection.showFieldInfo(clazz);
+    }
+
+    @Test
+    @DisplayName("reflection method 테스트")
+    public void reflectionMethodTest() {
+        BuchuClass buchuClass = new BuchuClass();
+        Class clazz = BuchuReflection.getClassByReflection(buchuClass);
+
+        BuchuReflection.showMethodInfo(clazz);
+    }
+}


### PR DESCRIPTION
런타임에 클래스 정보(클래스, 필드, 메소드 정보 등)를 가져오고 사용할 수 있는 자바의 Reflcetion을 실습해 보았습니다.

- 스프링의 IoC 컨테이너가 Bean이나 Component를 ApplicationContext에 등록하고 DI를 진행할 때
- HttpMessageConverter가 자바 객체를 JSON으로 직렬화/역직렬화 할 때
- JPA가 엔티티 객체를 생성할 때

등에 다채롭게 사용됩니다. 따라서 위와 같은 예시에서 객체의 기본 생성자가 존재하지 않으면 프레임워크나 라이브러리가 리플렉션을 통해 객체를 생성하여 이용하지 못하므로 public 생성자가 꼭 필요합니다.